### PR TITLE
removed unnecessary plugs, fixed versioning and removed `build-essential`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -26,6 +26,7 @@ apps:
       - home
       - audio-playback
       - network
+      - optical-drive
       - removable-media
     slots:
       - mpris

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: g4music
 base: core22
-version: '1.11'
 adopt-info: g4music
 grade: stable
 confinement: strict
@@ -36,7 +35,7 @@ apps:
 parts:  
   g4music:
     source: https://gitlab.gnome.org/neithern/g4music.git
-    source-tag: $SNAPCRAFT_PROJECT_VERSION
+    source-tag: '1.11'
     plugin: meson
     parse-info: [usr/share/metainfo/com.github.neithern.g4music.appdata.xml]
     meson-parameters:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,12 +1,14 @@
 name: g4music
 base: core22
+version: '1.11'
 adopt-info: g4music
 grade: stable
 confinement: strict
 compression: lzo
 architectures:
   - build-on: amd64
-    build-for: amd64
+  - build-on: arm64
+  - build-on: armhf
     
 slots:
   g4music:
@@ -24,9 +26,6 @@ apps:
       - home
       - audio-playback
       - network
-      - network-status
-      - raw-usb
-      - optical-drive
       - removable-media
     slots:
       - mpris
@@ -36,15 +35,12 @@ apps:
 parts:  
   g4music:
     source: https://gitlab.gnome.org/neithern/g4music.git
+    source-tag: $SNAPCRAFT_PROJECT_VERSION
     plugin: meson
     parse-info: [usr/share/metainfo/com.github.neithern.g4music.appdata.xml]
     meson-parameters:
       - -Dprefix=/usr
-    override-pull: |
-      craftctl default
-      craftctl set version=$(git describe --tags --abbrev=0)
     build-packages:
-      - build-essential
       - libgstreamer1.0-dev
       - libgstreamer-plugins-base1.0-dev
     


### PR DESCRIPTION
1. Raw-Usb to read the properties of a usb, removable-media will do what you want, though user need manually fix it.

2. Don't install `build-essential`, it's a meta-package which includes gcc, git etc packages, which aren't at all necessary

3. Added for all three architectures that are buildable.