### PR TITLE
version should not exist any letter

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: g4music
 base: core22
 adopt-info: g4music
+version: '1.11'
 grade: stable
 confinement: strict
 compression: lzo
@@ -43,6 +44,3 @@ parts:
     build-packages:
       - libgstreamer1.0-dev
       - libgstreamer-plugins-base1.0-dev
-    override-pull: |
-      craftctl default
-      craftctl set version=$(git describe --tags --abbrev=0)


### PR DESCRIPTION
Use version `1.11` not `v1.11`
Using `craftctl set` is adding the `v1.11`, which is very bad. So, use manual versioning instead, keep the build clean.