### PR TITLE
Fixed the versioning

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: g4music
 base: core22
 adopt-info: g4music
+version: '1.11'
 grade: stable
 confinement: strict
 compression: lzo
@@ -43,6 +44,3 @@ parts:
     build-packages:
       - libgstreamer1.0-dev
       - libgstreamer-plugins-base1.0-dev
-    override-pull: |
-      craftctl default
-      craftctl set version=$(git describe --tags --abbrev=0)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,6 @@
 name: g4music
 base: core22
 adopt-info: g4music
-version: '1.11'
 grade: stable
 confinement: strict
 compression: lzo
@@ -44,3 +43,6 @@ parts:
     build-packages:
       - libgstreamer1.0-dev
       - libgstreamer-plugins-base1.0-dev
+    override-pull:
+      craftctl default
+      craftctl set version=$(git describe --tags --abbrev=0 | cut -c 2-)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -43,6 +43,6 @@ parts:
     build-packages:
       - libgstreamer1.0-dev
       - libgstreamer-plugins-base1.0-dev
-    override-pull:
+    override-pull: |
       craftctl default
       craftctl set version=$(git describe --tags --abbrev=0 | cut -c 2-)


### PR DESCRIPTION
Whenver you try with this command

`craftctl set version=$(git describe --tags --abbrev=0 | cut -c 2-)`

It picks up the tag, and then cuts the first letter/number. In cases where tags start like this, `v1.11`, this `cut` command can be used, this makes no changes in the code itself